### PR TITLE
Simplify SDK download link

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ clone_depth: 1
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_SDK_URL: 'https://download.microsoft.com/download/8/8/5/88544F33-836A-49A5-8B67-451C24709A8F/dotnet-sdk-2.1.300-win-x64.zip'
+  DOTNET_SDK_URL: 'https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-win-x64.zip'
 
 cache:
   - '%LocalAppData%\NuGet\v3-cache' # NuGet v3


### PR DESCRIPTION
Replace the horrid download.microsoft.com link with something more readable.