### PR TITLE
Remove outdated references to `quiet` option (fixes #46)

### DIFF
--- a/dotnet-xdt/Program.cs
+++ b/dotnet-xdt/Program.cs
@@ -99,7 +99,6 @@ namespace DotNet.Xdt
             writer.WriteLine();
             writer.WriteLine("Options:");
             writer.WriteLine("  --help|-h|-?     Print usage information");
-            writer.WriteLine("  --quiet|-q       Print only error messages");
             writer.WriteLine("  --verbose|-v     Print verbose messages while transforming");
             writer.WriteLine();
             writer.WriteLine($"Example: {ToolName} --source original.xml --transform delta.xml --output final.xml --verbose");


### PR DESCRIPTION
Remove outdated references to `quiet` option (fixes #46)