### PR TITLE
Version 2.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use .NET 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100'
+        dotnet-version: '5.0.101'
 
     - name: build.ps1
       run: pwsh ./build.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
+    - name: Use .NET 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.100'
+
     - name: build.ps1
       run: pwsh ./build.ps1
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ is that you can use the same command, for both installation and usage, across al
 Install `dotnet-xdt` as a global tool (only once):
 
 ```cmd
-dotnet tool install --global dotnet-xdt --version 2.2.0
+dotnet tool install --global dotnet-xdt --version 2.2.1
 ```
 
 And then you can apply XDT transforms, from the command-line, anywhere on your PC, e.g.:
@@ -58,7 +58,7 @@ Download the latest build of `dotnet-xdt.exe` from the [releases page](https://g
 For complete flexibility, reference the cross-platform `DotNet.Xdt` NuGet package in your application:
 
 ```cmd
-dotnet add package DotNet.Xdt --version 2.2.0
+dotnet add package DotNet.Xdt --version 2.2.1
 ```
 
 You can apply XDT transforms to any XML file, or other XML sources that can be read from

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   DOTNET_NOLOGO: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_SDK_URL: 'https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100/dotnet-sdk-5.0.100-win-x64.zip'
+  DOTNET_SDK_URL: 'https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.101/dotnet-sdk-5.0.101-win-x64.zip'
 
 cache:
   - '%LocalAppData%\NuGet\v3-cache' # NuGet v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   DOTNET_NOLOGO: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_SDK_URL: 'https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.401/dotnet-sdk-3.1.401-win-x64.zip'
+  DOTNET_SDK_URL: 'https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100/dotnet-sdk-5.0.100-win-x64.zip'
 
 cache:
   - '%LocalAppData%\NuGet\v3-cache' # NuGet v3
@@ -45,5 +45,7 @@ artifacts:
   name: test-results/net48.xml
 - path: dotnet-xdt.tests/bin/$(configuration)/netcoreapp3.1/test-results.xml
   name: test-results/netcoreapp31.xml
+- path: dotnet-xdt.tests/bin/$(configuration)/net5.0/test-results.xml
+  name: test-results/net50.xml
 
 deploy: off

--- a/build.ps1
+++ b/build.ps1
@@ -9,11 +9,11 @@ function step($command) {
 $Env:DOTNET_NOLOGO = 'true'
 $Env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=lib  /p:ContinuosIntegrationBuild=true }
-step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=lib  /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=lib  /p:ContinuousIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=lib  /p:ContinuousIntegrationBuild=true }
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=tool /p:ContinuosIntegrationBuild=true }
-step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=tool /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=tool /p:ContinuousIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=tool /p:ContinuousIntegrationBuild=true }
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=exe  /p:ContinuosIntegrationBuild=true }
-step { dotnet msbuild dotnet-xdt /t:Build   /p:Configuration=Release /p:As=exe  /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=exe  /p:ContinuousIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Build   /p:Configuration=Release /p:As=exe  /p:ContinuousIntegrationBuild=true }

--- a/build.ps1
+++ b/build.ps1
@@ -9,11 +9,11 @@ function step($command) {
 $Env:DOTNET_NOLOGO = 'true'
 $Env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=lib }
-step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=lib }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=lib  /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=lib  /p:ContinuosIntegrationBuild=true }
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=tool }
-step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=tool }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=tool /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Pack    /p:Configuration=Release /p:As=tool /p:ContinuosIntegrationBuild=true }
 
-step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=exe }
-step { dotnet msbuild dotnet-xdt /t:Build   /p:Configuration=Release /p:As=exe }
+step { dotnet msbuild dotnet-xdt /t:Restore /p:Configuration=Release /p:As=exe  /p:ContinuosIntegrationBuild=true }
+step { dotnet msbuild dotnet-xdt /t:Build   /p:Configuration=Release /p:As=exe  /p:ContinuosIntegrationBuild=true }

--- a/dotnet-xdt.tests/dotnet-xdt.tests.csproj
+++ b/dotnet-xdt.tests/dotnet-xdt.tests.csproj
@@ -21,9 +21,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fixie" Version="2.2.1" />
-    <PackageReference Include="Shouldly" Version="4.0.0" />
-    <DotNetCliToolReference Include="Fixie.Console" Version="2.2.1" />
+    <PackageReference Include="Fixie" Version="2.2.2" />
+    <PackageReference Include="Shouldly" Version="4.0.1" />
+    <DotNetCliToolReference Include="Fixie.Console" Version="2.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dotnet-xdt\dotnet-xdt.csproj" />

--- a/dotnet-xdt.tests/dotnet-xdt.tests.csproj
+++ b/dotnet-xdt.tests/dotnet-xdt.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <LangVersion>preview</LangVersion>
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fixie" Version="2.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Shouldly" Version="4.0.0" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.2.1" />
   </ItemGroup>
   <ItemGroup>

--- a/dotnet-xdt.tests/dotnet-xdt.tests.csproj
+++ b/dotnet-xdt.tests/dotnet-xdt.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <LangVersion>preview</LangVersion>

--- a/dotnet-xdt/dotnet-xdt.csproj
+++ b/dotnet-xdt/dotnet-xdt.csproj
@@ -27,10 +27,13 @@
     <RootNamespace>DotNet.Xdt</RootNamespace>
     <AssemblyName>dotnet-xdt</AssemblyName>
 
-    <FileVersion>2.2.0</FileVersion>
+    <FileVersion>2.2.1</FileVersion>
     <Version>$(FileVersion)</Version>
     
-    <_ReleaseNotes>Enable [RollForward=Major](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#major-version-roll-forward) to allow running `dotnet-xdt` on .NET Core 3.x and later versions.</_ReleaseNotes>
+    <_ReleaseNotes>
+      Enable [RollForward=Major](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#major-version-roll-forward) to allow running `dotnet-xdt` on .NET Core 3.x and later versions.
+      Minor deterministic build and SourceLink support improvements.
+    </_ReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Label="Library" Condition=" '$(TargetFrameworks)' == '$(_LibTFM)' ">

--- a/dotnet-xdt/dotnet-xdt.csproj
+++ b/dotnet-xdt/dotnet-xdt.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
     <_ExeTFM>net461</_ExeTFM>
     <_LibTFM>netstandard2.0</_LibTFM>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.400"
+    "version": "5.0.100",
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.101",
     "rollForward": "latestMajor"
   }
 }

--- a/test.ps1
+++ b/test.ps1
@@ -9,6 +9,6 @@ function step($command) {
 $Env:DOTNET_NOLOGO = 'true'
 $Env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
 
-step { dotnet msbuild /t:Restore /p:Configuration=Release }
+step { dotnet msbuild /t:Restore /p:Configuration=Release /p:ContinuosIntegrationBuild=true }
 pushd dotnet-xdt.tests
 step { dotnet fixie --configuration Release --report test-results.xml }


### PR DESCRIPTION
Bump version to 2.2.1. 

Minor updates and improvements:
- build with .NET 5.0 SDK
- update test dependencies
- fully enable deterministic build
- expand SourceLink support to track auto-generated files (e.g. `AssemblyInfo.cs`)